### PR TITLE
Fixed Issues with SSR Mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "leptos_meta"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00900e82a4ca892828db93fce1d4c009480ff3959406e6965aa937c8bab7403"
+dependencies = [
+ "cfg-if",
+ "indexmap",
+ "leptos",
+ "tracing",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "leptos_reactive"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,6 +693,7 @@ version = "0.1.6"
 dependencies = [
  "js-sys",
  "leptos",
+ "leptos_meta",
  "wasm-bindgen",
  "web-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [".github"]
 [dependencies]
 js-sys = "0.3"
 leptos = "0.6"
+leptos_meta = { version = "0.6", optional = true }
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["EventTarget", "HtmlElement", "DomRect", "Element"] }
 
@@ -22,5 +23,5 @@ web-sys = { version = "0.3", features = ["EventTarget", "HtmlElement", "DomRect"
 # Enables the built-in <Toast /> component
 builtin_toast = []
 csr = ["leptos/csr"]
-ssr = ["leptos/ssr"]
+ssr = ["dep:leptos_meta","leptos/ssr","leptos_meta/ssr"]
 hydrate = ["leptos/hydrate"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 A Toaster component for Leptos heavily inspired by [sonner](https://sonner.emilkowal.ski/)
 
+## SSR
+If using SSR don't forget to set the features in your own Project correctly
+```toml
+[features]
+ssr = ["leptos_toaster/ssr"]
+hydrate = ["leptos_toaster/hydrate"]
+
+```
+
+
+
+
 ## Usage
 Somewhere, probably near the top of your component tree, add the Toaster component
 ```rust
@@ -15,7 +27,6 @@ view! {
 	</Toaster>
 }
 ```
-
 and then whenever you need a toast, do
 
 ```rust


### PR DESCRIPTION
By adding leptos_meta to dependencies when using feature flag ssr, it is now possible to compile it when using ssr.
Also changed Readme so nobody makes the same mistakes 